### PR TITLE
undisable the button before $apply, incase $apply wants to disable again.

### DIFF
--- a/stripe-angular.js
+++ b/stripe-angular.js
@@ -8,11 +8,11 @@ function($window) {
       var button = form.find('button');
       button.prop('disabled', true);
       $window.Stripe.createToken(form[0], function() {
+        button.prop('disabled', false);
         var args = arguments;
         scope.$apply(function() {
           scope[attributes.stripeForm].apply(scope, args);
         });
-        button.prop('disabled', false);
       });
     });
   };


### PR DESCRIPTION
I want to disable the button in my stripeResponseHandler, and I've had to put that in a $timeout to work around this. But this would be nicer.
