### PR TITLE
Resolves issue #6 - use scope.$eval() on attributes.stripeForm

### DIFF
--- a/stripe-angular.js
+++ b/stripe-angular.js
@@ -11,7 +11,7 @@ function($window) {
         button.prop('disabled', false);
         var args = arguments;
         scope.$apply(function() {
-          scope[attributes.stripeForm].apply(scope, args);
+          scope.$eval(attributes.stripeForm).apply(scope, args);
         });
       });
     });


### PR DESCRIPTION
Resolves issue #6 - use scope.$eval() on attributes.stripeForm to get binding reference.